### PR TITLE
Fix fixture grouping

### DIFF
--- a/archive/1990s/1998-99/1-premierleague.txt
+++ b/archive/1990s/1998-99/1-premierleague.txt
@@ -48,7 +48,6 @@ Matchday 3
 
 Matchday 4
 [Mon Sep/7]
-  Manchester United        4-1  Charlton
   Nottingham Forest        0-2  Everton
   Leeds                    3-0  Southampton
 [Tue Sep/8]
@@ -59,6 +58,7 @@ Matchday 4
   Derby                    1-0  Sheffield Wed
   Chelsea                  0-0  Arsenal
   Aston Villa              1-0  Newcastle Utd
+  Manchester United        4-1  Charlton
 
 
 Matchday 5


### PR DESCRIPTION
Man Utd vs Charlton should actually be in the second group of fixtures for Matchday 4. See:

https://www.premierleague.com/match/2563

This is slightly confusing, as it is now in the correct group, _but_ the fixture dates are all wrong. Fixture dates for PL are amended in #39 